### PR TITLE
cd /d instead of pushd

### DIFF
--- a/windepbuild.bat
+++ b/windepbuild.bat
@@ -4,7 +4,7 @@ setlocal EnableDelayedExpansion
 set    WORK_DIR=%~dp0
 set INSTALL_DIR=%~dp0\install_dir
 
-pushd "%WORK_DIR%"
+cd /d "%WORK_DIR%"
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 Rem git clone https://github.com/madler/zlib.git


### PR DESCRIPTION
otherwise we change the callers directory stack even on error. Don't want to confuse the already confusing dub cwd situation.