### PR TITLE
Windows: Don't build & link zlib

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -12,21 +12,14 @@
 	"preBuildCommands-windows" : [
 		"$PACKAGE_DIR\\windepbuild.bat"
 	],
-	"libs-posix" : ["xlsxwriter"],
+	"libs" : ["xlsxwriter"],
 	"lflags-posix": [
 		"-L$PACKAGE_DIR/libxlsxwriter/build/"
 	],
-	"lflags-windows-x86_mscoff-dmd": [
-		"\\\"/LIBPATH:$PACKAGE_DIR\\install_dir\\libxlsxwriter\\win32\\lib\\\"",
-		"\\\"/LIBPATH:$PACKAGE_DIR\\install_dir\\zlib\\win32\\lib\\\""
+	"lflags-windows-x86_mscoff": [
+		"/LIBPATH:$PACKAGE_DIR\\install_dir\\libxlsxwriter\\win32\\lib"
 	],
-	"lflags-windows-x86_64-dmd": [
-		"\\\"/LIBPATH:$PACKAGE_DIR\\install_dir\\libxlsxwriter\\lib\\\"",
-		"\\\"/LIBPATH:$PACKAGE_DIR\\install_dir\\zlib\\lib\\\""
-	],
-	"lflags-windows-x86_64-ldc": [
-		"\"\"/LIBPATH:$PACKAGE_DIR\\install_dir\\libxlsxwriter\\lib\\x64\\Release\"\"",
-		"\"\"/LIBPATH:$PACKAGE_DIR\\install_dir\\zlib\\lib\"\""
-	],
-	"libs-windows" : [ "msvcrt", "xlsxwriter", "zlibstatic" ]
+	"lflags-windows-x86_64": [
+		"/LIBPATH:$PACKAGE_DIR\\install_dir\\libxlsxwriter\\lib"
+	]
 }

--- a/dub.json
+++ b/dub.json
@@ -17,9 +17,9 @@
 		"-L$PACKAGE_DIR/libxlsxwriter/build/"
 	],
 	"lflags-windows-x86_mscoff": [
-		"/LIBPATH:$PACKAGE_DIR\\install_dir\\libxlsxwriter\\win32\\lib"
+"/LIBPATH:$PACKAGE_DIR\\install_dir\\libxlsxwriter\\lib\\Win32\\Release"
 	],
 	"lflags-windows-x86_64": [
-		"/LIBPATH:$PACKAGE_DIR\\install_dir\\libxlsxwriter\\lib"
+		"/LIBPATH:$PACKAGE_DIR\\install_dir\\libxlsxwriter\\lib\\x64\\Release"
 	]
 }

--- a/dub.json
+++ b/dub.json
@@ -9,8 +9,11 @@
 	"preBuildCommands-posix" : [
 		"make -C $PACKAGE_DIR libxlsxwriter/build/libxlsxwriter.a"
 	],
-	"preBuildCommands-windows" : [
-		"$PACKAGE_DIR\\windepbuild.bat"
+	"preBuildCommands-windows-x86_mscoff" : [
+		"$PACKAGE_DIR\\windepbuild.bat Win32"
+	],
+	"preBuildCommands-windows-x86_64" : [
+		"$PACKAGE_DIR\\windepbuild.bat x64"
 	],
 	"libs" : ["xlsxwriter"],
 	"lflags-posix": [

--- a/libxlsxwriter/CMakeLists.txt
+++ b/libxlsxwriter/CMakeLists.txt
@@ -158,9 +158,15 @@ enable_language(CXX)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 # ZLIB
-find_package(ZLIB REQUIRED "1.0")
-list(APPEND LXW_PRIVATE_INCLUDE_DIRS ${ZLIB_INCLUDE_DIRS})
-message("zlib version: " ${ZLIB_VERSION})
+if(WIN32)
+    # xlsxd-specific simplification on Windows: use zconf.h and zlib.h from ../zlib.
+    # This enables skipping the zlib build; the library is included in Phobos.
+    list(APPEND LXW_PRIVATE_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../zlib)
+else()
+    find_package(ZLIB REQUIRED "1.0")
+    list(APPEND LXW_PRIVATE_INCLUDE_DIRS ${ZLIB_INCLUDE_DIRS})
+    message("zlib version: " ${ZLIB_VERSION})
+endif()
 
 # MINIZIP
 if (USE_SYSTEM_MINIZIP)

--- a/windepbuild.bat
+++ b/windepbuild.bat
@@ -1,6 +1,8 @@
 @echo off
 setlocal EnableDelayedExpansion
 
+set ARCH=%1
+
 set    WORK_DIR=%~dp0
 set INSTALL_DIR=%~dp0\install_dir
 
@@ -8,44 +10,19 @@ cd /d "%WORK_DIR%"
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 Rem git clone https://github.com/jmcnamara/libxlsxwriter.git
-Rem x86
-if exist "%INSTALL_DIR%\libxlsxwriter\lib\Win32\Release\xlsxwriter.lib" (
-	echo 32-bit libxlsxwriter already built
+if exist "%INSTALL_DIR%\libxlsxwriter\lib\%ARCH%\Release\xlsxwriter.lib" (
+	echo %ARCH% libxlsxwriter already built
 ) else (
-	echo 32-bit libxlsxwriter does not exist
+	echo %ARCH% libxlsxwriter does not exist
 	cd libxlsxwriter
 	if !errorlevel! neq 0 exit /b !errorlevel!
-	mkdir build86
+	mkdir build_%ARCH%
 	if !errorlevel! neq 0 exit /b !errorlevel!
-	cd    build86
+	cd    build_%ARCH%
 	if !errorlevel! neq 0 exit /b !errorlevel!
-	cmake .. -DCMAKE_INSTALL_PREFIX="%INSTALL_DIR%\libxlsxwriter" -DCMAKE_GENERATOR_PLATFORM=Win32
+	cmake .. -DCMAKE_INSTALL_PREFIX="%INSTALL_DIR%\libxlsxwriter" -DCMAKE_GENERATOR_PLATFORM=%ARCH%
 	if !errorlevel! neq 0 exit /b !errorlevel!
 
 	cmake --build . --config Release --target install
-	if !errorlevel! neq 0 exit /b !errorlevel!
-
-	cd "%WORK_DIR%"
-	if !errorlevel! neq 0 exit /b !errorlevel!
-)
-
-Rem x64
-if exist "%INSTALL_DIR%\libxlsxwriter\lib\x64\Release\xlsxwriter.lib" (
-	echo 64-bit libxlsxwriter already built
-) else (
-	echo 64-bit libxlsxwriter does not exist
-	cd libxlsxwriter
-	if !errorlevel! neq 0 exit /b !errorlevel!
-	mkdir build
-	if !errorlevel! neq 0 exit /b !errorlevel!
-	cd    build
-	if !errorlevel! neq 0 exit /b !errorlevel!
-	cmake .. -DCMAKE_INSTALL_PREFIX="%INSTALL_DIR%\libxlsxwriter" -DCMAKE_GENERATOR_PLATFORM=x64
-	if !errorlevel! neq 0 exit /b !errorlevel!
-
-	cmake --build . --config Release --target install
-	if !errorlevel! neq 0 exit /b !errorlevel!
-
-	cd "%WORK_DIR%"
 	if !errorlevel! neq 0 exit /b !errorlevel!
 )

--- a/windepbuild.bat
+++ b/windepbuild.bat
@@ -7,49 +7,6 @@ set INSTALL_DIR=%~dp0\install_dir
 cd /d "%WORK_DIR%"
 if !errorlevel! neq 0 exit /b !errorlevel!
 
-Rem git clone https://github.com/madler/zlib.git
-Rem x86
-if exist "%INSTALL_DIR%\zlib\win32\lib\zlibstatic.lib" (
-	echo zlib already build
-)  else (
-	echo zlib does not exist
-	cd zlib
-	if !errorlevel! neq 0 exit /b !errorlevel!
-	mkdir buildx86
-	if !errorlevel! neq 0 exit /b !errorlevel!
-	cd    buildx86
-	if !errorlevel! neq 0 exit /b !errorlevel!
-	cmake .. -DCMAKE_INSTALL_PREFIX="%INSTALL_DIR%\zlib\win32" -DCMAKE_GENERATOR_PLATFORM=Win32
-	if !errorlevel! neq 0 exit /b !errorlevel!
-
-	cmake --build . --config Release  --target install
-	if !errorlevel! neq 0 exit /b !errorlevel!
-
-	cd "%WORK_DIR%"
-	if !errorlevel! neq 0 exit /b !errorlevel!
-)
-
-Rem x64
-if exist "%INSTALL_DIR%\zlib\lib\zlibstatic.lib" (
-	echo zlib already build
-)  else (
-	echo zlib does not exist
-	cd zlib
-	if !errorlevel! neq 0 exit /b !errorlevel!
-	mkdir build
-	if !errorlevel! neq 0 exit /b !errorlevel!
-	cd    build
-	if !errorlevel! neq 0 exit /b !errorlevel!
-	cmake .. -DCMAKE_INSTALL_PREFIX="%INSTALL_DIR%\zlib" -DCMAKE_GENERATOR_PLATFORM=x64
-	if !errorlevel! neq 0 exit /b !errorlevel!
-
-	cmake --build . --config Release  --target install
-	if !errorlevel! neq 0 exit /b !errorlevel!
-
-	cd "%WORK_DIR%"
-	if !errorlevel! neq 0 exit /b !errorlevel!
-)
-
 Rem git clone https://github.com/jmcnamara/libxlsxwriter.git
 Rem x86
 if exist "%INSTALL_DIR%\libxlsxwriter\win32\lib\xlsxwriter.lib" (
@@ -62,7 +19,7 @@ if exist "%INSTALL_DIR%\libxlsxwriter\win32\lib\xlsxwriter.lib" (
 	if !errorlevel! neq 0 exit /b !errorlevel!
 	cd    build86
 	if !errorlevel! neq 0 exit /b !errorlevel!
-	cmake .. -DCMAKE_INSTALL_PREFIX="%INSTALL_DIR%\libxlsxwriter\win32" -DZLIB_ROOT="%INSTALL_DIR%\zlib\win32" -DCMAKE_GENERATOR_PLATFORM=Win32
+	cmake .. -DCMAKE_INSTALL_PREFIX="%INSTALL_DIR%\libxlsxwriter\win32" -DCMAKE_GENERATOR_PLATFORM=Win32
 	if !errorlevel! neq 0 exit /b !errorlevel!
 
 	cmake --build . --config Release --target install
@@ -83,7 +40,7 @@ if exist "%INSTALL_DIR%\libxlsxwriter\lib\xlsxwriter.lib" (
 	if !errorlevel! neq 0 exit /b !errorlevel!
 	cd    build
 	if !errorlevel! neq 0 exit /b !errorlevel!
-	cmake .. -DCMAKE_INSTALL_PREFIX="%INSTALL_DIR%\libxlsxwriter" -DZLIB_ROOT="%INSTALL_DIR%\zlib" -DCMAKE_GENERATOR_PLATFORM=x64
+	cmake .. -DCMAKE_INSTALL_PREFIX="%INSTALL_DIR%\libxlsxwriter" -DCMAKE_GENERATOR_PLATFORM=x64
 	if !errorlevel! neq 0 exit /b !errorlevel!
 
 	cmake --build . --config Release --target install

--- a/windepbuild.bat
+++ b/windepbuild.bat
@@ -9,17 +9,17 @@ if !errorlevel! neq 0 exit /b !errorlevel!
 
 Rem git clone https://github.com/jmcnamara/libxlsxwriter.git
 Rem x86
-if exist "%INSTALL_DIR%\libxlsxwriter\win32\lib\xlsxwriter.lib" (
-	echo libxlsxwriter already build
+if exist "%INSTALL_DIR%\libxlsxwriter\lib\Win32\Release\xlsxwriter.lib" (
+	echo 32-bit libxlsxwriter already built
 ) else (
-	echo libxlsxwriter does not exist
+	echo 32-bit libxlsxwriter does not exist
 	cd libxlsxwriter
 	if !errorlevel! neq 0 exit /b !errorlevel!
 	mkdir build86
 	if !errorlevel! neq 0 exit /b !errorlevel!
 	cd    build86
 	if !errorlevel! neq 0 exit /b !errorlevel!
-	cmake .. -DCMAKE_INSTALL_PREFIX="%INSTALL_DIR%\libxlsxwriter\win32" -DCMAKE_GENERATOR_PLATFORM=Win32
+	cmake .. -DCMAKE_INSTALL_PREFIX="%INSTALL_DIR%\libxlsxwriter" -DCMAKE_GENERATOR_PLATFORM=Win32
 	if !errorlevel! neq 0 exit /b !errorlevel!
 
 	cmake --build . --config Release --target install
@@ -30,10 +30,10 @@ if exist "%INSTALL_DIR%\libxlsxwriter\win32\lib\xlsxwriter.lib" (
 )
 
 Rem x64
-if exist "%INSTALL_DIR%\libxlsxwriter\lib\xlsxwriter.lib" (
-	echo libxlsxwriter already build
+if exist "%INSTALL_DIR%\libxlsxwriter\lib\x64\Release\xlsxwriter.lib" (
+	echo 64-bit libxlsxwriter already built
 ) else (
-	echo libxlsxwriter does not exist
+	echo 64-bit libxlsxwriter does not exist
 	cd libxlsxwriter
 	if !errorlevel! neq 0 exit /b !errorlevel!
 	mkdir build


### PR DESCRIPTION
Instead, use the 2 header files directly from the included zlib source and depend on the zlib symbols from Phobos when linking.

The main rationale is that this prevents linker conflicts with Phobos DLL.