### PR TITLE
Windows: Enable linking against both dynamic and static MSVCRT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
+dist: bionic
 language: d
-sudo: false
 
-os:
-  - linux
+os: linux
 
 d:
   - dmd

--- a/windepbuild.bat
+++ b/windepbuild.bat
@@ -20,7 +20,7 @@ if exist "%INSTALL_DIR%\libxlsxwriter\lib\%ARCH%\Release\xlsxwriter.lib" (
 	if !errorlevel! neq 0 exit /b !errorlevel!
 	cd    build_%ARCH%
 	if !errorlevel! neq 0 exit /b !errorlevel!
-	cmake .. -DCMAKE_INSTALL_PREFIX="%INSTALL_DIR%\libxlsxwriter" -DCMAKE_GENERATOR_PLATFORM=%ARCH%
+	cmake .. -DCMAKE_INSTALL_PREFIX="%INSTALL_DIR%\libxlsxwriter" -DCMAKE_GENERATOR_PLATFORM=%ARCH% -DUSE_STATIC_MSVC_RUNTIME=ON
 	if !errorlevel! neq 0 exit /b !errorlevel!
 
 	cmake --build . --config Release --target install


### PR DESCRIPTION
Previously, the default libxlsxwriter CMake settings required the final binary to be linked against the dynamic MSVCRT; D compilers
default to the static one.